### PR TITLE
Add plugin_row_meta links and update plugin header

### DIFF
--- a/public/admin/class-indexnow-url-submission-admin.php
+++ b/public/admin/class-indexnow-url-submission-admin.php
@@ -146,8 +146,7 @@ class BWT_IndexNow_Admin {
 	 * @param string $plugin_file Current plugin file basename.
 	 * @return array Modified row-meta links.
 	 */
-	public function add_plugin_row_meta($existing, $plugin_file)
-	{
+	public function add_plugin_row_meta($existing, $plugin_file) {
 		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . 'indexnow-url-submission.php' );
 		if ($plugin_file !== $plugin_basename) {
 			return $existing;

--- a/public/admin/class-indexnow-url-submission-admin.php
+++ b/public/admin/class-indexnow-url-submission-admin.php
@@ -139,6 +139,31 @@ class BWT_IndexNow_Admin {
 		return array_merge($settings_link, $links);
 	}
 
+	/**
+	 * Add plugin row meta links (GitHub, etc.).
+	 *
+	 * @param array $existing Existing row-meta links.
+	 * @param string $plugin_file Current plugin file basename.
+	 * @return array Modified row-meta links.
+	 */
+	public function add_plugin_row_meta($existing, $plugin_file)
+	{
+		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . 'indexnow-url-submission.php' );
+		if ($plugin_file !== $plugin_basename) {
+			return $existing;
+		}
+
+		$new_links = array(
+			sprintf(
+				'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+				esc_url( 'https://github.com/jespinal/indexnow-wordpress-plugin-ce' ),
+				__( 'GitHub', 'indexnow' )
+			),
+		);
+
+		return array_merge($existing, $new_links);
+	}
+
 	// This function checks the type of update on a page/post and accordingly calls the submit api if enabled
 	public function on_post_published($new_status, $old_status, $post)
 	{

--- a/public/admin/class-indexnow-url-submission-admin.php
+++ b/public/admin/class-indexnow-url-submission-admin.php
@@ -142,8 +142,8 @@ class BWT_IndexNow_Admin {
 	/**
 	 * Add plugin row meta links (GitHub, etc.).
 	 *
-	 * @param array $existing Existing row-meta links.
-	 * @param string $plugin_file Current plugin file basename.
+	 * @param array  $existing    Array of existing plugin row meta links.
+	 * @param string $plugin_file Plugin file path relative to the plugins directory.
 	 * @return array Modified row-meta links.
 	 */
 	public function add_plugin_row_meta($existing, $plugin_file) {

--- a/public/includes/class-indexnow-url-submission.php
+++ b/public/includes/class-indexnow-url-submission.php
@@ -123,6 +123,9 @@ class BWT_IndexNow {
 		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . 'indexnow-url-submission.php' );
 		$this->loader->add_filter( 'plugin_action_links_' . $plugin_basename, $plugin_admin, 'add_action_links' );
 
+		// Add row-meta links (Visit site, GitHub) under the plugin description.
+		$this->loader->add_filter( 'plugin_row_meta', $plugin_admin, 'add_plugin_row_meta', 10, 2 );
+
 		// Add url submit action & post publishing.
 		$this->loader->add_action( 'transition_post_status', $plugin_admin, 'on_post_published', 10, 3 );
 	}

--- a/public/indexnow-url-submission.php
+++ b/public/indexnow-url-submission.php
@@ -1,25 +1,22 @@
 <?php
 
-/**
- * @link              https://github.com/jespinal/indexnow-wordpress-plugin-ce
- * @since             2.0.0
- * @package           IndexNow_CommunityEdition
- *
- * @wordpress-plugin
+/*
  * Plugin Name:       IndexNow Community Edition
- * Plugin URI:        https://github.com/jespinal/indexnow-wordpress-plugin-ce
+ * Plugin URI:        https://pavelespinal.com/wordpress-plugins-indexnow-community-edition
  * Description:       Personal fork of IndexNow plugin for WordPress with modern compatibility
  * Version:           2.0.0
- * Author:            jespinal
+ * Requires at least: 6.0
+ * Requires PHP:      8.3
+ * Author:            Pavel Espinal
  * Author URI:        https://github.com/jespinal
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:       indexnow-community
+ * Text Domain:       indexnow
  * Domain Path:       /languages
- * Requires at least: 6.0
- * Tested up to: 6.8
- * Requires PHP: 8.3
- *
+ * Update URI:        false
+ */
+
+/**
  * Based on the original IndexNow plugin by Microsoft Bing
  * Original plugin: https://github.com/microsoft/indexnow-wordpress-plugin
  * This is a personal fork with modern WordPress compatibility


### PR DESCRIPTION
Add plugin_row_meta links (Visit plugin site + GitHub) to the IndexNow plugin so row-meta matches PE-Category-Filter. Also update plugin header Plugin URI to point to the hosted plugin page.

Changes:
- Register `plugin_row_meta` in the loader
- Implement `add_plugin_row_meta` in the admin class
- Update plugin header information

This keeps the plugin list appearance consistent between forks and adds a link to the plugin site.